### PR TITLE
Added queries for metrics

### DIFF
--- a/examples/ENPKG/1.ttl
+++ b/examples/ENPKG/1.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <https://kg.earthmetabolome.org/metrin/api/.well-known/examples/>.
+@prefix ex: <https://enpkg.commons-lab.org/graphdb/.well-known/examples/>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix schema: <https://schema.org/>.
 @prefix sh: <http://www.w3.org/ns/shacl#>.

--- a/examples/ENPKG/2.ttl
+++ b/examples/ENPKG/2.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <https://kg.earthmetabolome.org/metrin/api/.well-known/examples/>.
+@prefix ex: <https://enpkg.commons-lab.org/graphdb/.well-known/examples/>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix schema: <https://schema.org/>.
 @prefix sh: <http://www.w3.org/ns/shacl#>.

--- a/examples/ENPKG/3.ttl
+++ b/examples/ENPKG/3.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <https://kg.earthmetabolome.org/metrin/api/.well-known/examples/> .
+@prefix ex: <https://enpkg.commons-lab.org/graphdb/.well-known/examples/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/ENPKG/9.ttl
+++ b/examples/ENPKG/9.ttl
@@ -1,4 +1,4 @@
-@prefix ex: <https://kg.earthmetabolome.org/metrin/api/.well-known/examples/> .
+@prefix ex: <https://enpkg.commons-lab.org/graphdb/.well-known/examples/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/examples/METRINKG/30.ttl
+++ b/examples/METRINKG/30.ttl
@@ -1,0 +1,32 @@
+@prefix ex: <https://kg.earthmetabolome.org/metrin/api/.well-known/examples/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix spex:<https://purl.expasy.org/sparql-examples/ontology#> .
+
+ex:30 a sh:SPARQLExecutable,
+        sh:SPARQLSelectExecutable ;
+    rdfs:comment "Metrics for retrieving TRY species, trait and non-trait records."@en ;
+    sh:prefixes _:sparql_examples_prefixes ;
+    sh:select """PREFIX emi: <https://w3id.org/emi#>
+PREFIX sosa: <http://www.w3.org/ns/sosa/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT 
+  (COUNT(DISTINCT ?trySpName) AS ?speciesCount)
+  (COUNT(DISTINCT ?traitData) AS ?traitCount)
+  (COUNT(DISTINCT ?nonTraitData) AS ?nonTraitCount)
+WHERE {
+  ?trySpName emi:inTaxon ?wdx .						
+  ?trySpObs sosa:isSampleOf ?trySpName ;
+            sosa:isFeatureOfInterestOf ?tryObId .
+  ?tryObId sosa:hasResult ?tryData .
+  ?tryData rdfs:label ?tryDataLab ;
+           rdf:value ?tryDataVal .
+
+  # separate trait vs. non-trait
+  OPTIONAL { ?tryData rdf:type emi:Trait     . BIND(?tryData AS ?traitData) }
+  OPTIONAL { ?tryData rdf:type emi:NonTrait  . BIND(?tryData AS ?nonTraitData) }
+}""" ;
+    schema:target <https://kg.earthmetabolome.org/metrin/api/> .

--- a/examples/METRINKG/31.ttl
+++ b/examples/METRINKG/31.ttl
@@ -1,0 +1,32 @@
+@prefix ex: <https://kg.earthmetabolome.org/metrin/api/.well-known/examples/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix spex:<https://purl.expasy.org/sparql-examples/ontology#> .
+
+ex:31 a sh:SPARQLExecutable,
+        sh:SPARQLSelectExecutable ;
+    rdfs:comment "Unique Wikidata identifiers mapped to GloBI taxons."@en ;
+    sh:prefixes _:sparql_examples_prefixes ;
+    sh:select """PREFIX emi: <https://w3id.org/emi#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT (COUNT(DISTINCT ?wdx) AS ?totalDistinctTaxa) 
+WHERE {
+  ?intxn emi:hasSource ?source ;
+         emi:hasTarget ?target ;
+         emi:isClassifiedWith ?intxnType .
+  ?intxnType rdfs:label ?intxnLabel .
+  ?source emi:inTaxon ?wdx_Source ;
+          rdfs:label ?sourceName .
+  ?target emi:inTaxon ?wdx_Target ;
+          rdfs:label ?targetName .
+  # merge sources and targets into a single ?wdx variable
+  {
+    ?source emi:inTaxon ?wdx
+  }
+  UNION {
+    ?target emi:inTaxon ?wdx
+  }
+}""" ;
+    schema:target <https://kg.earthmetabolome.org/metrin/api/> .

--- a/examples/METRINKG/32.ttl
+++ b/examples/METRINKG/32.ttl
@@ -6,7 +6,7 @@
 
 ex:32 a sh:SPARQLExecutable,
         sh:SPARQLSelectExecutable ;
-    rdfs:comment "Unique Wikidata identifiers mapped to GloBI taxons."@en ;
+    rdfs:comment "Metrics for GloBI records (total number of interactions) for only those taxons that possess a Wikidata ID ."@en ;
     sh:prefixes _:sparql_examples_prefixes ;
     sh:select """PREFIX emi: <https://w3id.org/emi#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>

--- a/examples/METRINKG/32.ttl
+++ b/examples/METRINKG/32.ttl
@@ -1,0 +1,25 @@
+@prefix ex: <https://kg.earthmetabolome.org/metrin/api/.well-known/examples/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix spex:<https://purl.expasy.org/sparql-examples/ontology#> .
+
+ex:32 a sh:SPARQLExecutable,
+        sh:SPARQLSelectExecutable ;
+    rdfs:comment "Unique Wikidata identifiers mapped to GloBI taxons."@en ;
+    sh:prefixes _:sparql_examples_prefixes ;
+    sh:select """PREFIX emi: <https://w3id.org/emi#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT (COUNT(*) AS ?rowCount) 
+WHERE {
+  ?intxn emi:hasSource ?source ;
+         emi:hasTarget ?target ;
+         emi:isClassifiedWith ?intxnType .
+  ?intxnType rdfs:label ?intxnLabel .
+  ?source emi:inTaxon ?wdx_Source ;
+          rdfs:label ?sourceName .
+  ?target emi:inTaxon ?wdx_Target ;
+          rdfs:label ?targetName .
+}""" ;
+    schema:target <https://kg.earthmetabolome.org/metrin/api/> .


### PR DESCRIPTION
These queries are also available as plain text files in METRIN-KG repo (https://github.com/earth-metabolome-initiative/metrin-kg/tree/main/metrics). Now, they will reside here with official versioned records. For back-up the original records in METRIN-KG will remain.